### PR TITLE
Plug a minor memory leak

### DIFF
--- a/src/MultiSrc.c
+++ b/src/MultiSrc.c
@@ -1060,7 +1060,7 @@ InitStringOrFile(MultiSrcObject src, Boolean newString)
 	    length = strlen(src->multi_src.string);
 
 	    /* Wasteful, throwing away the WC string, but need side effect! */
-            (void) _XawTextMBToWC(d, src->multi_src.string, &length);
+	    XtFree((XtPointer)_XawTextMBToWC(d, src->multi_src.string, &length));
 	    src->multi_src.length = (XawTextPosition) length;
 	} else {
 	    src->multi_src.length = strlen(src->multi_src.string);
@@ -1249,8 +1249,10 @@ LoadPieces(MultiSrcObject src, FILE *file, char *string)
       ptr += piece->used;
   } while (left > 0);
 
-  if ( temp_mb_holder )
-      XtFree( (char*) temp_mb_holder );
+  if ((char *)local_str != temp_mb_holder)
+      XtFree((XtPointer)local_str);
+  if (temp_mb_holder)
+      XtFree(temp_mb_holder);
 }
 
 

--- a/src/TextSrc.c
+++ b/src/TextSrc.c
@@ -580,6 +580,7 @@ _XawTextMBToWC(Display *d, char *str, int *len_in_out)
     XtFree(buf);
     if (XwcTextPropertyToTextList(d, &textprop,
 			(wchar_t***)&wlist, &count) != Success) {
+	XtFree((XtPointer)textprop.value);
 	XtWarningMsg("convertError", "multiSourceCreate", "XawError",
 		 "Non-character code(s) in source.", NULL, NULL);
 	*len_in_out = 0;
@@ -588,6 +589,7 @@ _XawTextMBToWC(Display *d, char *str, int *len_in_out)
     wstr = wlist[0];
     *len_in_out = wcslen(wstr);
     XFree((char**)wlist); /* this is evil */
+    XtFree((XtPointer)textprop.value);
     return(wstr);
   }
 }


### PR DESCRIPTION
 Creating a text widget as follows triggers multibyte-to-widechar conversion (specifically the combination of !XtNuseStringInPlace && XtNInternational) which leaks memory:

```c
text = XtVaCreateManagedWidget("text", asciiTextWidgetClass, toplevel,
                               XtNstring, "Text Widget",
                               XtNuseStringInPlace, False,
                               XtNinternational, True,
                               NULL);
```

The return value of ``_XawTextMBToWC()`` is allocated on the heap, as is the value in the XTextProp used in obtaining it.